### PR TITLE
fix(ci): release.yml から main ブランチトリガーを削除 (#8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
## 概要

Closes #8

## 変更内容

- `.github/workflows/release.yml` の `on.push.branches` セクション（`- main`）を削除
- タグ push（`v*.*.*`）によるトリガーのみ維持

## テスト

- `v*.*.*` タグ push 時にワークフローが起動することを確認
- main ブランチへの push 時にワークフローが起動しないことを確認

## レビュー観点

- タグトリガーが正しく残っているか
- 他のワークフローへの影響がないか