### PR TITLE
feat(settings): ログイン時に起動トグルを設定画面に追加 (#14)

### DIFF
--- a/todoist-focus-widget/package.json
+++ b/todoist-focus-widget/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-autostart": "^2",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/todoist-focus-widget/src-tauri/Cargo.toml
+++ b/todoist-focus-widget/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ resvg = "0.44"
 
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png", "macos-private-api"] }
+tauri-plugin-autostart = "2"
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/todoist-focus-widget/src-tauri/capabilities/main.json
+++ b/todoist-focus-widget/src-tauri/capabilities/main.json
@@ -11,6 +11,9 @@
     "core:window:allow-set-position",
     "core:window:allow-set-focus",
     "core:window:allow-start-dragging",
-    "core:default"
+    "core:default",
+    "autostart:allow-is-enabled",
+    "autostart:allow-enable",
+    "autostart:allow-disable"
   ]
 }

--- a/todoist-focus-widget/src-tauri/src/lib.rs
+++ b/todoist-focus-widget/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use tauri::{
     tray::TrayIconBuilder,
     Manager, LogicalPosition,
 };
+use tauri_plugin_autostart::MacosLauncher;
 use todoist::{fetch_p1_tasks, close_task, Task};
 
 #[tauri::command]
@@ -68,7 +69,7 @@ fn open_settings(app: &tauri::AppHandle) {
         tauri::WebviewUrl::App("index.html".into()),
     )
     .title("Todoist Focus Widget – 設定")
-    .inner_size(420.0, 230.0)
+    .inner_size(420.0, 270.0)
     .resizable(false)
     .build();
 }
@@ -78,6 +79,7 @@ pub fn run() {
     let _ = dotenvy::dotenv();
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_autostart::init(MacosLauncher::LaunchAgent, None))
         .plugin(tauri_plugin_shell::init())
         .invoke_handler(tauri::generate_handler![
             get_tasks, complete_task, open_url, get_token, save_token

--- a/todoist-focus-widget/src/Settings.css
+++ b/todoist-focus-widget/src/Settings.css
@@ -129,3 +129,50 @@ body {
   color: #ff3b30;
   font-size: 13px;
 }
+
+/* ── インライン行フィールド（ラベル + コントロール横並び） ── */
+.settings-field--row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.settings-field--row label {
+  margin-bottom: 0;
+}
+
+/* ── トグルスイッチ ── */
+.toggle-switch {
+  appearance: none;
+  -webkit-appearance: none;
+  position: relative;
+  width: 44px;
+  height: 26px;
+  border-radius: 13px;
+  background: #e5e5ea;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+
+.toggle-switch::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  transition: transform 0.2s;
+}
+
+.toggle-switch--on {
+  background: #34c759;
+}
+
+.toggle-switch--on::after {
+  transform: translateX(18px);
+}

--- a/todoist-focus-widget/src/Settings.tsx
+++ b/todoist-focus-widget/src/Settings.tsx
@@ -1,14 +1,17 @@
 import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { enable, disable, isEnabled } from "@tauri-apps/plugin-autostart";
 import "./Settings.css";
 
 export default function Settings() {
   const [token, setToken] = useState("");
   const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
+  const [autostart, setAutostart] = useState(false);
 
   useEffect(() => {
     invoke<string>("get_token").then(setToken).catch(() => {});
+    isEnabled().then(setAutostart).catch(() => {});
   }, []);
 
   const handleSave = async () => {
@@ -18,6 +21,19 @@ export default function Settings() {
       setTimeout(() => setStatus("idle"), 2000);
     } catch {
       setStatus("error");
+    }
+  };
+
+  const handleAutostartToggle = async () => {
+    try {
+      if (autostart) {
+        await disable();
+      } else {
+        await enable();
+      }
+      setAutostart(!autostart);
+    } catch {
+      // autostart の変更に失敗しても UI はそのまま
     }
   };
 
@@ -53,6 +69,16 @@ export default function Settings() {
           </a>
           {" "}から取得できます
         </p>
+      </div>
+
+      <div className="settings-field settings-field--row">
+        <label>ログイン時に起動</label>
+        <button
+          role="switch"
+          aria-checked={autostart}
+          className={`toggle-switch${autostart ? " toggle-switch--on" : ""}`}
+          onClick={handleAutostartToggle}
+        />
       </div>
 
       <div className="settings-actions">


### PR DESCRIPTION
## 概要

Closes #14

## 変更内容

- `tauri-plugin-autostart` を Rust / npm に追加し、macOS LaunchAgent 経由で自動起動を制御
- 設定画面に「ログイン時に起動」macOS スタイルのトグルスイッチを追加
- トグル操作と同時に LaunchAgent への登録/解除を実行
- 設定画面を開いたとき現在の登録状態をトグルに反映
- capabilities に `autostart:allow-*` 権限 3 件を追加
- 設定ウィンドウ高さを 230 → 270 に拡張

## テスト

- 設定画面を開き、トグルの初期状態が現在の自動起動設定と一致することを確認
- トグルを ON → OFF → ON と切り替え、LaunchAgent への登録/解除が反映されることを確認

## レビュー観点

- `MacosLauncher::LaunchAgent` の選択が適切か（`AppleScript` との違い）
- トグルエラー時のサイレント失敗が適切か